### PR TITLE
add modelId weights for item limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Inventory Weight plugin for Minecraft ([Spigot](https://www.spigotmc.org/) 1
 
 The plugin configuration is managed through a YAML file called config.yml. Below is a breakdown of the available options.
 
-### 1. **Weight Limit Configuration**
+### **Weight Limit Configuration**
 
 ```yaml
 weightLimit: 500
@@ -35,7 +35,7 @@ disableMovement: true
 - **`disableMovement`**: If `true`, once the player reaches or exceeds the weight limit, they will be unable to move until they reduce their weight. Default is `true`.
 - **`blindAtMax: true`**: If `true`, the player will be blinded when they reach the weight limit. Default is `false`. This can be beneficial because player's can not sprint when they're blinded. Which prevents the player from "jump sprinting" which can bypass the speed reduction.
 
-### 2. **Player Movement Speed**
+### **Player Movement Speed**
 
 ```yaml
 maxWalkSpeed: 0.30
@@ -47,7 +47,7 @@ beginSlowdown: 0.0
 - **`minWalkSpeed`**: Defines the player's walking speed once the inventory weight reaches or exceeds the `weightLimit`. Default is `0.05`.
 - **`beginSlowdown`**: Sets the percentage of the weight limit at which the player’s speed will begin to decrease. For example, if set to `0.5`, speed reduction will start when the player reaches 50% of the weight limit. Default is `0.0`, meaning slowdown begins immediately.
 
-### 3. **Update Frequency**
+### **Update Frequency**
 
 ```yaml
 checkInventoryTimer: 2
@@ -55,7 +55,7 @@ checkInventoryTimer: 2
 
 - **`checkInventoryTimer`**: Specifies the time in seconds for how frequently the plugin will recalculate the player’s inventory weight. Default is `2` seconds.
 
-### 4. **World-Specific Behavior**
+### **World-Specific Behavior**
 
 ```yaml
 worlds: []
@@ -68,7 +68,7 @@ worlds: []
     - nether
   ```
 
-### 5. **Armor-Only Weight Calculation**
+### **Armor-Only Weight Calculation**
 
 ```yaml
 armorOnly: false
@@ -76,9 +76,9 @@ armorOnly: false
 
 - **`armorOnly`**: When set to `true`, only the armor slots will contribute to the player’s total inventory weight. Default is `false`.
 
-### 6. **Item Weights and Custom Weights**
+### **Item Weights and Custom Weights**
 
-When defining item weights, you can set custom weights for specific materials, custom item names, and lore tags. When there are conflicts the order of importance is as follows: lore tags, custom item name, material then default weight.
+When defining item weights, you can set custom weights for specific materials, custom item names, and lore tags. When there are conflicts the order of importance is as follows: item model id, lore tags, custom item name, material then default weight.
 
 #### Default Item Weight
 
@@ -100,6 +100,16 @@ materialWeights:
 
 - **`materialWeights`**: Define custom weights for specific materials. A full list of available materials can be found [here](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html).
 
+#### Custom Item Weights by Model ID
+
+```yaml
+modelIdWeights:
+  - modelId: 1000
+    weight: 13
+```
+
+- **`modelIdWeights`**: Custom item model IDs can have specific weights. This is useful when using plugins like Oraxen that add custom items with unique model IDs.
+
 #### Custom Item Weights by Name
 
 ```yaml
@@ -110,7 +120,7 @@ customItemWeights:
 
 - **`customItemWeights`**: Custom item names can have specific weights, even if they share the same material type as other items.
 
-### 7. **Lore Tags for Custom Weight**
+### **Lore Tags for Custom Weight**
 
 ```yaml
 loreTag: 'Weight:'
@@ -120,15 +130,19 @@ capacityTag: 'Capacity:'
 - **`loreTag`**: Add a custom lore line to any item with the format `Weight: X` where `X` is the weight value. The plugin will recognize this lore and use it to set the item’s weight.
 - **`capacityTag`**: Custom lore tags can also be used to indicate an item’s carrying capacity.
 
-### 8. **Item Limits**
+### **Item Limits**
 
 ```yaml
 itemLimits:
   - material: SHULKER_BOX
     limit: 5
+  - limit: 5
+    modelId: 1000 # use custom model id with plugin like oraxen
+  - material: SHULKER_BOX
+    permission: 'somepermission.node' # only applied to people with the perm
 ```
 
-- **`itemLimits`**: Limits the number of specific items a player can carry. For example, a player can carry no more than `5` shulker boxes. If they exceed this limit, they will be treated as if they’ve exceeded the max weight. This format checks if materials have the same name, so GREEN_SHULKER_BOX will be included in the count.
+- **`itemLimits`**: Limits the number of specific items a player can carry. For example, a player can carry no more than `5` shulker boxes. If they exceed this limit, they will be treated as if they’ve exceeded the max weight. This format checks if materials have the same name, so GREEN_SHULKER_BOX will be included in the count. You can also use permissions to limit items to specific players. Use modelId instead of material to specify custom items. Material and modelId are optional, but at least one must be present, if both are present, the modelId will be used.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.williamsaada</groupId>
     <artifactId>InventoryWeight</artifactId>
-    <version>2.20.2</version>
+    <version>2.21.0</version>
     <build>
         <defaultGoal>clean validate deploy</defaultGoal>
         <finalName>${project.name}-${project.version}</finalName>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/wonka01/InventoryWeight/commands/GetWeightCommand.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/GetWeightCommand.java
@@ -10,7 +10,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 public class GetWeightCommand implements SubCommand {
-    public void onCommand(Player player, String[] args) {
+    public void onCommand(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', "You must be a player to use this command"));
+            return;
+        }
+        Player player = (Player) sender;
+
         if (args.length < 2) {
             ItemStack item = player.getInventory().getItemInMainHand();
             if (item.getType() == Material.AIR) {
@@ -33,10 +39,6 @@ public class GetWeightCommand implements SubCommand {
             player.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     LanguageConfig.getConfig().getMessages().getItemWeight() + " " + weight));
         }
-    }
-
-    public void onCommand(CommandSender sender, String[] args) {
-        throw new NotImplementedException();
     }
 
 }

--- a/src/main/java/me/wonka01/InventoryWeight/commands/HelpCommand.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/HelpCommand.java
@@ -1,19 +1,12 @@
 package me.wonka01.InventoryWeight.commands;
 
 import me.wonka01.InventoryWeight.configuration.LanguageConfig;
-import org.apache.commons.lang.NotImplementedException;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 public class HelpCommand implements SubCommand {
-    public void onCommand(Player player, String[] args) {
-        player.sendMessage(
+    public void onCommand(CommandSender sender, String[] args) {
+        sender.sendMessage(
                 ChatColor.translateAlternateColorCodes('&', LanguageConfig.getConfig().getMessages().getHelpMessage()));
     }
-
-    public void onCommand(CommandSender sender, String[] args) {
-        throw new NotImplementedException();
-    }
-
 }

--- a/src/main/java/me/wonka01/InventoryWeight/commands/InventoryWeightCommands.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/InventoryWeightCommands.java
@@ -6,19 +6,22 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
-public class InventoryWeightCommands implements CommandExecutor {
+public class InventoryWeightCommands implements CommandExecutor, TabCompleter {
 
     private InventoryWeight plugin = JavaPlugin.getPlugin(InventoryWeight.class);
     private HashMap<String, SubCommand> subCommands;
     private final String main = "inventoryweight";
 
     public void setup() {
-
         plugin.getCommand(main).setExecutor(this);
         subCommands = new HashMap<String, SubCommand>();
         subCommands.put("weight", new WeightCommand());
@@ -28,23 +31,33 @@ public class InventoryWeightCommands implements CommandExecutor {
     }
 
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-
-        if (!(sender instanceof Player)) {
-            return false;
-        }
-        Player player = (Player) sender;
         if (args.length < 1) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', LanguageConfig.getConfig().getMessages().getHelpMessage()));
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                    LanguageConfig.getConfig().getMessages().getHelpMessage()));
             return true;
         }
         String sub = args[0];
 
         if (subCommands.containsKey(sub)) {
-            subCommands.get(sub).onCommand(player, args);
+            subCommands.get(sub).onCommand(sender, args);
             return true;
         } else {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', LanguageConfig.getConfig().getMessages().getInvalidCommand()));
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                    LanguageConfig.getConfig().getMessages().getInvalidCommand()));
             return true;
         }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            for (String sub : subCommands.keySet()) {
+                if (sub.startsWith(args[0].toLowerCase())) {
+                    completions.add(sub);
+                }
+            }
+        }
+        return completions;
     }
 }

--- a/src/main/java/me/wonka01/InventoryWeight/commands/ReloadCommand.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/ReloadCommand.java
@@ -2,30 +2,24 @@ package me.wonka01.InventoryWeight.commands;
 
 import me.wonka01.InventoryWeight.InventoryWeight;
 import me.wonka01.InventoryWeight.configuration.LanguageConfig;
-import org.apache.commons.lang.NotImplementedException;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class ReloadCommand implements SubCommand {
 
-    public void onCommand(Player player, String[] args) {
+    public void onCommand(CommandSender sender, String[] args) {
 
-        if (!player.hasPermission("inventoryweight.reload")) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+        if (!sender.hasPermission("inventoryweight.reload") && !(sender instanceof ConsoleCommandSender)) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     LanguageConfig.getConfig().getMessages().getNoPermission()));
             return;
         }
 
         JavaPlugin.getPlugin(InventoryWeight.class).reloadConfiguration();
-        player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+        sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                 LanguageConfig.getConfig().getMessages().getReloadCommand()));
 
     }
-
-    public void onCommand(CommandSender sender, String[] args) {
-        throw new NotImplementedException();
-    }
-
 }

--- a/src/main/java/me/wonka01/InventoryWeight/commands/SetWeightCommand.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/SetWeightCommand.java
@@ -3,28 +3,27 @@ package me.wonka01.InventoryWeight.commands;
 import me.wonka01.InventoryWeight.configuration.LanguageConfig;
 import me.wonka01.InventoryWeight.util.InventoryCheckUtil;
 import me.wonka01.InventoryWeight.util.MaterialUtil;
-import org.apache.commons.lang.NotImplementedException;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
+import org.bukkit.command.ConsoleCommandSender;
 
 public class SetWeightCommand implements SubCommand {
 
-    public void onCommand(Player player, String[] args) {
+    public void onCommand(CommandSender sender, String[] args) {
 
-        if (!player.hasPermission("inventoryweight.set")) {
-            player.sendMessage(LanguageConfig.getConfig().getMessages().getNoPermission());
+        if (!sender.hasPermission("inventoryweight.set") && !(sender instanceof ConsoleCommandSender)) {
+            sender.sendMessage(LanguageConfig.getConfig().getMessages().getNoPermission());
             return;
         }
 
         if (args.length < 3 || !args[2].matches("\\d+(\\.\\d{1,2})?")) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     LanguageConfig.getConfig().getMessages().getInvalidCommand()));
             return;
         }
 
         if (!MaterialUtil.isMaterialValid(args[1])) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     LanguageConfig.getConfig().getMessages().getInvalidMaterial()));
             return;
         }
@@ -33,11 +32,6 @@ public class SetWeightCommand implements SubCommand {
         double weight = Double.parseDouble(args[2]);
 
         InventoryCheckUtil.mapOfWeightsByMaterial.put(materialAllCaps, weight);
-        player.sendMessage(ChatColor.GREEN + "Set the weight of " + materialAllCaps + " to " + weight);
+        sender.sendMessage(ChatColor.GREEN + "Set the weight of " + materialAllCaps + " to " + weight);
     }
-
-    public void onCommand(CommandSender sender, String[] args) {
-        throw new NotImplementedException();
-    }
-
 }

--- a/src/main/java/me/wonka01/InventoryWeight/commands/SubCommand.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/SubCommand.java
@@ -1,11 +1,7 @@
 package me.wonka01.InventoryWeight.commands;
 
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
 
 public interface SubCommand {
-    void onCommand(Player player, String[] args);
-
     void onCommand(CommandSender player, String[] args);
 }

--- a/src/main/java/me/wonka01/InventoryWeight/commands/WeightCommand.java
+++ b/src/main/java/me/wonka01/InventoryWeight/commands/WeightCommand.java
@@ -13,7 +13,13 @@ import org.bukkit.entity.Player;
 import java.text.DecimalFormat;
 
 public class WeightCommand implements SubCommand {
-    public void onCommand(Player player, String[] args) {
+    public void onCommand(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', "You must be a player to use this command"));
+            return;
+        }
+
+        Player player = (Player) sender;
         WorldList worldList = WorldList.getInstance();
         if (player.hasPermission("inventoryweight.off") || player.getGameMode().equals(GameMode.CREATIVE)
                 || !(worldList.isInventoryWeightEnabled(player.getWorld().getName()))) {
@@ -32,9 +38,4 @@ public class WeightCommand implements SubCommand {
                 LanguageConfig.getConfig().getMessages().getSpeed() + ": &a" + playerWeight.getPercentage() + "%"));
         player.sendMessage(ChatColor.WHITE + "[" + playerWeight.getSpeedDisplay() + ChatColor.WHITE + "]");
     }
-
-    public void onCommand(CommandSender sender, String[] args) {
-        throw new NotImplementedException();
-    }
-
 }

--- a/src/main/java/me/wonka01/InventoryWeight/playerweight/ItemLimit.java
+++ b/src/main/java/me/wonka01/InventoryWeight/playerweight/ItemLimit.java
@@ -1,19 +1,39 @@
 package me.wonka01.InventoryWeight.playerweight;
 
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
 // Class that represents the item limit with the limit and the permission needed for it to be counted
 public class ItemLimit {
     private int limit;
     private String permission;
+    private String material;
+    private int customModelId;
 
-    public ItemLimit(int limit, String permission) {
+    public ItemLimit(int limit, String permission, String material) {
         this.limit = limit;
         this.permission = permission;
+        this.material = material;
+        this.customModelId = -1;
+    }
+
+    public ItemLimit(int limit, String permission, int customModelId) {
+        this.limit = limit;
+        this.permission = permission;
+        this.material = "MODELID";
+        this.customModelId = customModelId;
     }
 
     public int getLimit() {
         return limit;
+    }
+
+    public int getCustomModelId() {
+        return customModelId;
+    }
+
+    public String getMaterial() {
+        return material.toUpperCase();
     }
 
     public String getPermission() {

--- a/src/main/java/me/wonka01/InventoryWeight/util/Items.java
+++ b/src/main/java/me/wonka01/InventoryWeight/util/Items.java
@@ -1,0 +1,18 @@
+package me.wonka01.InventoryWeight.util;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class Items {
+    static int getCustomModelData(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) {
+            return -1;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null && meta.hasCustomModelData()) {
+            return meta.getCustomModelData();
+        }
+        return -1;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -66,10 +66,16 @@ customItemWeights:
   - name: Diamond Sword of Doom
     weight: 20
 
+modelIdWeights:
+  - modelId: 1000
+    weight: 13
+
 # Limit the amount of a specific item that player's can have in their inventory.
 # In this example, a player can not have more than 5 shulker boxes in their inventory.
 # When player is over the limit they will be treated as if they've gone over the max weight.
 itemLimits:
+  - limit: 5
+    modelId: 1000
   - material: SHULKER_BOX
     limit: 5
-    permission: 'somepermission.node'
+    # permission: 'somepermission.node' optionally add a permission for the limit

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -19,4 +19,4 @@ helpMessage:
   &7- &a/iw reload &f- Reload the plugin configuration.
 
   &eManage your inventory wisely to avoid slowing down or being unable to move!"
-overLimitMessage: '&cYou are carrying too many Shulker Boxes, you need to drop some!'
+overLimitMessage: '&cYou are carrying too much, you need to drop something!'


### PR DESCRIPTION
- new modelIdWeights list for setting weights to items based on it's model id. Great for use with plugins like Oraxen
- itemLimits can also be specified with a modelId instead of just materials like:
itemLimits:
```
  - limit: 5
    modelId: 1000
```
- commands can now be run from the console / not just players
- basic tab complete for commands